### PR TITLE
Update node version in custom functions env

### DIFF
--- a/docs/8base-console/custom-functions/README.md
+++ b/docs/8base-console/custom-functions/README.md
@@ -72,7 +72,7 @@ await ctx.api.gqlRequest(QUERY, VARIABLES, {
 ```
 
 ### Managing Dependencies
-8base deploys CFs to a Node.js 8.10 runtime environment in which any compatible NPM dependencies are supported. On deploy, the system will check whether or not your dependencies have been installed and handle that accordingly. As expected, deploys run significantly faster when dependencies are installed locally. Feel free to use either NPM or Yarn as your package manager during development.
+8base deploys CFs to a Node.js 10 runtime environment in which any compatible NPM dependencies are supported. On deploy, the system will check whether or not your dependencies have been installed and handle that accordingly. As expected, deploys run significantly faster when dependencies are installed locally. Feel free to use either NPM or Yarn as your package manager during development.
 
 ### Development Tips
 CFs are developed in a local development environment and then deployed to a given workspace using the [8base CLI](../../development-tools/cli). When in development, they can be invoked locally for testing purposes. 


### PR DESCRIPTION
I don't know the exact node version custom functions run in (happy to update this with it), but according to [this answer on the community](https://community.8base.com/t/node-8-in-documentation-aws-eol/126/5), it was updated to node 10 in December. The docs should be updated to reflect this.